### PR TITLE
Process all Import elements and add clockwork.yml

### DIFF
--- a/clockwork.yml
+++ b/clockwork.yml
@@ -1,0 +1,3 @@
+name: xml-preprocessor
+version: 1.0.0
+description: Allows Python expressions and reduces duplication in Google-Samsung Watch Face Format XML.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,0 @@
-{
-    "name": "xml-preprocessor",
-    "version": "1.0.0"
-}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "xml-preprocessor",
+    "version": "1.0.0"
+}


### PR DESCRIPTION
- #### Process all import elements
`<Import/>` elements no longer need to be a direct child of the root XML element.

> [!NOTE]
> *Documentation will need to be updated to reflect this change*

- #### Add [`clockwork.yml`](https://clockwork-pkg.pages.dev/developers/package)